### PR TITLE
Removed parenthesis from continuation token.

### DIFF
--- a/Connection.ts
+++ b/Connection.ts
@@ -43,7 +43,7 @@ export class Connection {
 				path +
 				(continuationName && this.continuation[continuationName] && continuation
 					? (path.includes("?") ? "&" : "?") +
-					  `continuation=${encodeURIComponent(this.continuation[continuationName] ?? "")})`
+					  `continuation=${encodeURIComponent(this.continuation[continuationName] ?? "")}`
 					: "")
 			let response
 			try {


### PR DESCRIPTION
There is an extra parethesis in the string.
There shouldn't be any parenthesis inside the string.